### PR TITLE
Added support for shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 ## Bootstrappr
 
-A bare-bones tool to install a set of packages on a target volume.  
-Typically these would be packages that "enroll" the machine into your management system; upon reboot these tools would take over and continue the setup and configuration of the machine.
-
-Add desired packages to the bootstrap/packages directory. Ensure all packages you add can be properly installed to volumes other than the current boot volume.
+A bare-bones tool to install a set of packages and scripts on a target volume.  
+Typically these would be packages or scripts that "enroll" the machine into your management system; upon reboot these tools would take over and continue the setup and configuration of the machine.
 
 Bootstrappr is designed to be able to run in Recovery mode, allowing you to "bootstrap" a machine fresh out of the box without having to run the Setup Assistant, manually creating a local account, and other unreliable manual tasks.
 
+### Packages
+
+Add desired packages to the `bootstrap/packages` directory. Ensure all packages you add can be properly installed to volumes other than the current boot volume.
+
+If your packages just have payloads, they should work fine. Pre- and postinstall scripts need to be checked to not use absolute paths to the current startup volume. The installer system passes the target volume in the third argument `$3` to installation scripts.
+
+### Scripts
+
+Bootstrappr will check that script filenames end with the `.sh` extension and have the executable bit set. Other files will be ignored.
+
+Keep in mind that the Recovery system does not have the same set of tools available the the full macOS has. `Python`, `ruby`, `zsh`, `osascript`, `systemsetup`, `networksetup` and many others are *not* available in the Recovery system, write your scripts accordingly. Using `bash` for your scripts is the safest choice.
+
+If in doubt boot to Recovery and test.
+
+### Order
+
+Bootstrappr will work through scripts and packages in alphanumerical order. To control the order, you can prefix filenames with numbers.
+
 #### iMac Pro
+
 Bootstrappr is particularly useful with the new iMac Pro, which does not support NetBoot, and is tricky to get to boot from external media. To set up a new machine, you'd pull the machine out of the box, boot into Recovery (Command-R at start up), and mount the Bootstrappr disk and run Bootstappr.
 
 ### Usage scenarios

--- a/bootstrap/bootstrappr.sh
+++ b/bootstrap/bootstrappr.sh
@@ -37,7 +37,7 @@ echo "Installing packages to /Volumes/${SELECTEDVOLUME}..."
 # so we get to use Bash pattern matching
 BASENAME=${0##*/}
 THISDIR=${0%$BASENAME}
-PACKAGESDIR="${THISDIR}/../testdir"
+PACKAGESDIR="${THISDIR}packages"
 
 for ITEM in "${PACKAGESDIR}"/* ; do
 	FILENAME="${ITEM##*/}"

--- a/bootstrap/bootstrappr.sh
+++ b/bootstrap/bootstrappr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bootstrappr.sh
-# A script to install packages found in a packages folder in the same directory
+# A script to install packages and scripts found in a packages folder in the same directory
 # as this script to a selected volume
 
 if [[ $EUID != 0 ]] ; then
@@ -39,8 +39,27 @@ BASENAME=${0##*/}
 THISDIR=${0%$BASENAME}
 PACKAGESDIR="${THISDIR}packages"
 
-for PKG in $(/bin/ls -1 "${PACKAGESDIR}"/*.pkg) ; do
-    /usr/sbin/installer -pkg "${PKG}" -target "/Volumes/${SELECTEDVOLUME}"
+for ITEM in "${PACKAGESDIR}"/* ; do
+	FILENAME="${ITEM##*/}"
+	EXTENSION="${FILENAME##*.}"
+	if [[ -e ${ITEM} ]]; then
+		case ${EXTENSION} in
+			sh ) 
+				if [[ -x ${ITEM} ]]; then
+					echo "running script:  ${FILENAME}"
+					# pass the selected volume to the script as $1
+					${ITEM} "/Volumes/${SELECTEDVOLUME}"
+				else
+					echo "${FILENAME} is not executable"
+				fi
+				;;
+			pkg ) 
+				echo "install package: ${FILENAME}"
+				/usr/sbin/installer -pkg "${ITEM}" -target "/Volumes/${SELECTEDVOLUME}"
+				;;
+			* ) echo "unsupported file extension: ${ITEM}" ;;
+		esac
+	fi
 done
 
 echo


### PR DESCRIPTION
Now the script scan the `packages` folder for shell scripts (executable `.sh` files) as well as pkgs.

Shell scripts will have the full path to the selected volume passed as the first argument `$1`